### PR TITLE
Removed set Immediate

### DIFF
--- a/components/discover/trendly/TrendlyAdvancedFilter.tsx
+++ b/components/discover/trendly/TrendlyAdvancedFilter.tsx
@@ -350,9 +350,7 @@ const TrendlyAdvancedFilter = (props: IProps) => {
     props.FilterApplyRef.current = (action: string) => {
         setOffset(0)
         if (action == "apply") {
-            setImmediate(() => {
-                callApiRef.current(true)
-            })
+            callApiRef.current(true)
         } else {
             resetCallApiRef.current()
         }

--- a/contexts/brand-context.provider.tsx
+++ b/contexts/brand-context.provider.tsx
@@ -309,7 +309,11 @@ export const BrandContextProvider: React.FC<PropsWithChildren & { restrictForPay
     }
   }, [selectedBrand])
 
-  const isOnFreeTrial = selectedBrand && (!selectedBrand.isBillingDisabled && selectedBrand.billing?.status != ModelStatus.Accepted)
+  const isOnFreeTrial = useMemo(() => {
+    if (!selectedBrand)
+      return false
+    return (!selectedBrand.isBillingDisabled && !selectedBrand.billing)
+  }, [selectedBrand])
 
   const ctxValue = useMemo(() => ({
     brands,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Filter application now triggers the API immediately when applying Trendly filters, making filter application slightly snappier while keeping non-apply behavior unchanged.

- **Bug Fixes / Behavior**
  - Free-trial availability logic adjusted: trial state is now derived more strictly (hidden when no brand selected and gated by billing data), which may change when free-trial UI appears.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->