### PR TITLE
Gate LinkedIn Page behind a feature flag

### DIFF
--- a/constants/Socials.ts
+++ b/constants/Socials.ts
@@ -1,4 +1,4 @@
-import { REDDIT_ENABLED } from "@/constants/features";
+import { LINKEDIN_PAGE_ENABLED, REDDIT_ENABLED } from "@/constants/features";
 import { ISocialAccount } from "@/contexts/brand-social-context.provider";
 import { IconProp } from "@fortawesome/fontawesome-svg-core";
 import {
@@ -93,12 +93,15 @@ const ALL_SOCIAL_PLATFORMS: SocialPlatformMeta[] = [
 
 /**
  * The platforms a brand can connect, gated by feature flags. Reddit is hidden
- * until REDDIT_ENABLED is turned on (see constants/features.ts). The MAP below is
- * built from the FULL list so display lookups (icon/label/color) still resolve
- * for any account that somehow exists.
+ * until REDDIT_ENABLED is turned on, and LinkedIn Page is hidden until
+ * LINKEDIN_PAGE_ENABLED is turned on (see constants/features.ts) — personal
+ * LinkedIn stays enabled. The MAP below is built from the FULL list so display
+ * lookups (icon/label/color) still resolve for any account that somehow exists.
  */
 export const SOCIAL_PLATFORMS: SocialPlatformMeta[] = ALL_SOCIAL_PLATFORMS.filter(
-    (p) => p.key !== "reddit" || REDDIT_ENABLED
+    (p) =>
+        (p.key !== "reddit" || REDDIT_ENABLED) &&
+        (p.key !== "linkedin_page" || LINKEDIN_PAGE_ENABLED)
 );
 
 export const SOCIAL_PLATFORM_MAP: Record<SocialPlatform, SocialPlatformMeta> =

--- a/constants/features.ts
+++ b/constants/features.ts
@@ -12,3 +12,16 @@
  * portal flag (trendly-connect `lib/config.ts` REDDIT_ENABLED).
  */
 export const REDDIT_ENABLED = false;
+
+/**
+ * LINKEDIN_PAGE_ENABLED gates only the LinkedIn Page (Company/Showcase Page)
+ * integration — NOT personal LinkedIn, which stays enabled. Company Page
+ * access requires LinkedIn's Community Management API app review, which is
+ * taking too long, so this is PAUSED until that review clears. While false,
+ * LinkedIn Page never appears as a connectable / publishable / inbox channel.
+ *
+ * To enable: flip this to true AND the backend flag
+ * (backend-sls `internal/constants/features.go` LinkedInPageEnabled) and the
+ * connect portal flag (trendly-connect `lib/config.ts` LINKEDIN_PAGE_ENABLED).
+ */
+export const LINKEDIN_PAGE_ENABLED = false;


### PR DESCRIPTION
## Summary
- LinkedIn's Community Management API app review is taking too long, so hide the LinkedIn Page (company/showcase page) connect tile until the review clears.
- Personal LinkedIn (posting only, no CMA scopes) is unaffected and stays enabled.
- New `LINKEDIN_PAGE_ENABLED` flag in `constants/features.ts`, mirroring the existing `REDDIT_ENABLED` pattern — flip back to `true` once LinkedIn approves the CMA app.

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Verify the connect grid ("Add a platform") no longer shows a LinkedIn Page tile, while LinkedIn (personal) still does