### PR TITLE
Gate LinkedIn Page out of publish/inbox destination lists too

### DIFF
--- a/components/contents/detail/PostingSummary.tsx
+++ b/components/contents/detail/PostingSummary.tsx
@@ -4,7 +4,7 @@ import {
     ScheduleMode,
     SocialDestination,
 } from "@/components/contents/types";
-import { REDDIT_ENABLED } from "@/constants/features";
+import { LINKEDIN_PAGE_ENABLED, REDDIT_ENABLED } from "@/constants/features";
 import Colors from "@/shared-uis/constants/Colors";
 import {
     faBolt,
@@ -24,10 +24,10 @@ import { Image, Pressable, StyleSheet, Text, View } from "react-native";
 
 // Platforms Trendly can publish to. Kept in sync with ScheduleBar's set so the
 // recap chips match the destinations the user actually selected. Reddit is gated
-// by REDDIT_ENABLED.
+// by REDDIT_ENABLED, LinkedIn Page by LINKEDIN_PAGE_ENABLED.
 const PUBLISHABLE = new Set(
     ["instagram", "facebook", "linkedin", "linkedin_page", "twitter", "youtube", "reddit"].filter(
-        (p) => p !== "reddit" || REDDIT_ENABLED
+        (p) => (p !== "reddit" || REDDIT_ENABLED) && (p !== "linkedin_page" || LINKEDIN_PAGE_ENABLED)
     )
 );
 

--- a/components/contents/detail/ScheduleBar.tsx
+++ b/components/contents/detail/ScheduleBar.tsx
@@ -1,7 +1,7 @@
 import DateField from "@/components/modals/DateField";
 import { ISocialAccount, socialAccountLabel } from "@/contexts/brand-social-context.provider";
 import { PlatformOptions, POPULAR_POSTING_TIMES, ScheduleMode, SocialDestination } from "@/components/contents/types";
-import { REDDIT_ENABLED } from "@/constants/features";
+import { LINKEDIN_PAGE_ENABLED, REDDIT_ENABLED } from "@/constants/features";
 import Colors from "@/shared-uis/constants/Colors";
 import {
     faBolt,
@@ -52,10 +52,11 @@ interface ScheduleBarProps {
 }
 
 // Platforms Trendly can publish to. Each has a backend publish path
-// (internal/trendlyapis/publishing/publish.go). Reddit is gated by REDDIT_ENABLED.
+// (internal/trendlyapis/publishing/publish.go). Reddit is gated by REDDIT_ENABLED,
+// LinkedIn Page by LINKEDIN_PAGE_ENABLED.
 const PUBLISHABLE = new Set(
     ["instagram", "facebook", "linkedin", "linkedin_page", "twitter", "youtube", "reddit"].filter(
-        (p) => p !== "reddit" || REDDIT_ENABLED
+        (p) => (p !== "reddit" || REDDIT_ENABLED) && (p !== "linkedin_page" || LINKEDIN_PAGE_ENABLED)
     )
 );
 

--- a/components/inbox/data/use-inbox.api.ts
+++ b/components/inbox/data/use-inbox.api.ts
@@ -21,7 +21,7 @@
 import { collection, onSnapshot } from "firebase/firestore";
 import { useCallback, useEffect, useState } from "react";
 
-import { REDDIT_ENABLED } from "@/constants/features";
+import { LINKEDIN_PAGE_ENABLED, REDDIT_ENABLED } from "@/constants/features";
 import { useBrandContext } from "@/contexts/brand-context.provider";
 import { FirestoreDB } from "@/shared-libs/utils/firebase/firestore";
 import { HttpWrapper } from "@/shared-libs/utils/http-wrapper";
@@ -42,7 +42,7 @@ import {
  */
 const INBOX_CHANNELS = new Set(
     ["instagram", "facebook", "linkedin_page", "twitter", "reddit"].filter(
-        (c) => c !== "reddit" || REDDIT_ENABLED
+        (c) => (c !== "reddit" || REDDIT_ENABLED) && (c !== "linkedin_page" || LINKEDIN_PAGE_ENABLED)
     )
 );
 


### PR DESCRIPTION
## Summary
Follow-up to #420. That PR gated the connect tile via `SOCIAL_PLATFORMS`, but a full audit of every `REDDIT_ENABLED` usage turned up three more places that independently list `linkedin_page` without going through `SOCIAL_PLATFORMS`:

- `components/contents/detail/ScheduleBar.tsx` — `PUBLISHABLE` set (publish destination picker)
- `components/contents/detail/PostingSummary.tsx` — `PUBLISHABLE` set (destination recap chips)
- `components/inbox/data/use-inbox.api.ts` — `INBOX_CHANNELS` set (inbox connected-account mapping)

All three already had a Reddit filter; added the matching `LINKEDIN_PAGE_ENABLED` filter to each. Personal LinkedIn is untouched.

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Verify LinkedIn Page can't be selected as a publish destination and doesn't appear in the inbox channel list